### PR TITLE
cheshire: Use Fatload boot, modify Makefiles for GCC 13

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -24,7 +24,7 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
 	CMODEL = medany
 endif
 
-ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C) -mabi=$(ABI) \
+ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C)_zicsr_zifencei -mabi=$(ABI) \
 	     -mcmodel=$(CMODEL)
 
 PLATFORM_CPPFLAGS	+= $(ARCH_FLAGS)

--- a/configs/pulp-platform_cheshire_defconfig
+++ b/configs/pulp-platform_cheshire_defconfig
@@ -10,7 +10,7 @@ CONFIG_BOOTDELAY=5
 CONFIG_HUSH_PARSER=y
 CONFIG_USE_BOOTCOMMAND=y
 # Boot with mmc if mmc probes normally, else boot with spi (get CS from "boot-with" in device tree)
-CONFIG_BOOTCOMMAND="fdt addr ${fdtcontroladdr}; if mmc info; then mmc read 90000000 2000 5000; else fdt get value boot-with /soc/spi boot-with; if sf probe 0:${boot-with}; then sf read 90000000 400000 800000; fi; fi; bootm 90000000 - ${fdtcontroladdr};"
+CONFIG_BOOTCOMMAND="fdt addr ${fdtcontroladdr}; if mmc info; then fatload mmc 0:4 90000000 uImage; else fdt get value boot-with /soc/spi boot-with; if sf probe 0:${boot-with}; then sf read 90000000 400000 800000; fi; fi; bootm 90000000 - ${fdtcontroladdr};"
 CONFIG_DISPLAY_CPUINFO=y
 CONFIG_SPL_SPI_FLASH_MTD=y
 CONFIG_CMD_GPT=y
@@ -23,6 +23,7 @@ CONFIG_MMC=y
 # CONFIG_MMC_WRITE is not set
 CONFIG_MMC_SPI=y
 CONFIG_DM_MTD=y
+CONFIG_CMD_FAT=y
 CONFIG_MTDIDS_DEFAULT="nor0=spi0.0"
 CONFIG_MTDPARTS_DEFAULT="mtdparts=spi0.0:-(all)"
 CONFIG_DM_DEBUG=y


### PR DESCRIPTION
This replaces the Kernel loading mechanism to use the fatload command which reads the uImage file from a FAT partition. This makes Kernel Image loading independent from uImage size and removes the need for hardcoding blockcounts.