### PR TITLE
[Cheshire] Read 32 MiB instead of 8 MiB when booting from SPI

### DIFF
--- a/configs/pulp-platform_cheshire_defconfig
+++ b/configs/pulp-platform_cheshire_defconfig
@@ -10,7 +10,7 @@ CONFIG_BOOTDELAY=5
 CONFIG_HUSH_PARSER=y
 CONFIG_USE_BOOTCOMMAND=y
 # Boot with mmc if mmc probes normally, else boot with spi (get CS from "boot-with" in device tree)
-CONFIG_BOOTCOMMAND="fdt addr ${fdtcontroladdr}; if mmc info; then fatload mmc 0:4 90000000 uImage; else fdt get value boot-with /soc/spi boot-with; if sf probe 0:${boot-with}; then sf read 90000000 400000 800000; fi; fi; bootm 90000000 - ${fdtcontroladdr};"
+CONFIG_BOOTCOMMAND="fdt addr ${fdtcontroladdr}; if mmc info; then fatload mmc 0:4 90000000 uImage; else fdt get value boot-with /soc/spi boot-with; if sf probe 0:${boot-with}; then sf read 90000000 400000 2000000; fi; fi; bootm 90000000 - ${fdtcontroladdr};"
 CONFIG_DISPLAY_CPUINFO=y
 CONFIG_SPL_SPI_FLASH_MTD=y
 CONFIG_CMD_GPT=y


### PR DESCRIPTION
The RVV-enabled linux image needs more than 8 MiB.